### PR TITLE
Fix #128: Replace deprecated tool.uv.dev-dependencies with dependency-groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,8 @@ Repository = "https://github.com/bcorfman/arcade_actions"
 Documentation = "https://github.com/bcorfman/arcade_actions/blob/main/docs/"
 Issues = "https://github.com/bcorfman/arcade_actions/issues"
 
-
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=8.3.3",
     "pytest-cov>=5.0.0",
     "build>=1.2.2.post1",


### PR DESCRIPTION
## Description
Fixes issue #128 by migrating from the deprecated `[tool.uv].dev-dependencies` format to the modern `[dependency-groups]` format in `pyproject.toml`.

## Changes Made
- Replaced `[tool.uv].dev-dependencies` with `[dependency-groups].dev`
- Maintains identical dependency list and versions
- Uses the recommended modern uv dependency group format

## Testing
- Verified functionality with `uv sync --group dev` command
- All dev dependencies install correctly with new format
- No functional changes, only modernizes configuration syntax

## Background
The `tool.uv.dev-dependencies` field is deprecated in favor of the PEP 735 `dependency-groups` standard. This change eliminates the GitHub Actions warning about the deprecated field.

Resolves #128