### PR TITLE
Fix #141:  Examples not working due to MoveUntil API change and callback signature bug

### DIFF
--- a/examples/easing_demo.py
+++ b/examples/easing_demo.py
@@ -121,7 +121,7 @@ class EaseDemoView(arcade.View):
     def _launch_missile(self, missile, ease_func, label):
         """Launch a missile with smooth acceleration using Ease wrapper."""
 
-        def on_boundary_hit(sprite, axis):
+        def on_boundary_hit(sprite, axis, side):
             """Reset missile position when it hits the right boundary."""
             sprite.center_x = X_START
             sprite.trail_points.clear()
@@ -134,7 +134,7 @@ class EaseDemoView(arcade.View):
             condition=infinite,  # Never stop on its own
             bounds=bounds,
             boundary_behavior="wrap",
-            on_boundary=on_boundary_hit,
+            on_boundary_exit=on_boundary_hit,
         )
 
         # Wrap with Ease for smooth acceleration to cruise speed

--- a/examples/space_clutter.py
+++ b/examples/space_clutter.py
@@ -120,7 +120,7 @@ class Starfield:
             condition=infinite,
             bounds=bounds,
             boundary_behavior="wrap",
-            on_boundary=self.on_stars_wrap,
+            on_boundary_exit=self.on_stars_wrap,
         )
 
     def update(self):

--- a/examples/stars.py
+++ b/examples/stars.py
@@ -110,7 +110,7 @@ class StarfieldView(arcade.View):
             condition=infinite,
             bounds=bounds,
             boundary_behavior="wrap",
-            on_boundary=self.on_stars_wrap,
+            on_boundary_exit=self.on_stars_wrap,
         )
         wrapping_action.apply(self.star_list)
 


### PR DESCRIPTION
This PR Fixes #141 i.e updates the following example scripts to restore correct functionality after recent changes to the `MoveUntil` API:
- easing_demo.py
- space_clutter.py
- stars.py

**Changes:**
- Replaces `on_boundary` with `on_boundary_exit` in all affected examples.
- Updates boundary callback functions to accept three arguments: `(sprite, axis, side)` as required by the new API.

**Testing:**
- All examples now run without TypeError and demonstrate expected boundary behavior.